### PR TITLE
Implement token-based admin authentication and update docs

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -92,6 +92,15 @@ fly secrets set FLASK_ENV=production
 
 # Set any other required secrets
 fly secrets set YOUR_SECRET_KEY=your_value
+
+# Token used to authorize admin routes
+fly secrets set ADMIN_TOKEN=your_admin_token
+```
+
+Admin endpoints now require an `Authorization` header with this token:
+
+```bash
+curl -H "Authorization: Bearer $ADMIN_TOKEN" https://yourdomain.com/admin/usage
 ```
 
 ### **3. Database Setup (if needed)**

--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ import traceback
 import time
 import threading
 import shutil
+from functools import wraps
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from flask import Flask, send_from_directory, current_app, render_template, make_response, redirect, request, abort
@@ -93,6 +94,17 @@ def configure_celery(app, celery_instance):
                 return super().__call__(*args, **kwargs)
     celery_instance.Task = ContextTask
 
+def admin_required(f):
+    """Verify that the request contains a valid admin token."""
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        token = current_app.config.get('ADMIN_TOKEN')
+        auth = request.headers.get('Authorization', '')
+        if not token or not auth.startswith('Bearer ') or auth.split(' ', 1)[1] != token:
+            abort(401)
+        return f(*args, **kwargs)
+    return wrapper
+
 def create_app():
     app = Flask(__name__, 
                 static_folder=os.path.join(os.path.dirname(__file__), 'static'),
@@ -100,6 +112,7 @@ def create_app():
     
     config_class = ProductionConfig if os.environ.get('FLASK_ENV') == 'production' else DevelopmentConfig
     app.config.from_object(config_class)
+    app.config['ADMIN_TOKEN'] = os.environ.get('ADMIN_TOKEN')
 
     # Ensure the upload folder exists
     upload_folder = app.config.get('UPLOAD_FOLDER')
@@ -138,13 +151,10 @@ def create_app():
         db.create_all()
 
     # -------------------- Admin routes (defined BEFORE catch-all) --------------------
-    ADMIN_KEY = os.environ.get('ADMIN_KEY', 'your-secret-key')
 
     @app.route('/admin/usage')
+    @admin_required
     def view_usage():
-        # Simple key check; replace with proper auth later
-        if request.args.get('key') != ADMIN_KEY:  # IMPORTANT: Change this to a strong, secret key
-            abort(401)
         logs = APILog.query.order_by(APILog.timestamp.desc()).limit(100).all()
         html = "<h2>API Usage Log</h2><table border='1'><tr><th>Time</th><th>IP</th><th>Path</th><th>Method</th><th>User-Agent</th></tr>"
         for log in logs:
@@ -153,10 +163,8 @@ def create_app():
         return html
 
     @app.route('/admin/job-metrics')
+    @admin_required
     def view_job_metrics():
-        # Simple key check; replace with proper auth later
-        if request.args.get('key') != ADMIN_KEY:
-            abort(401)
         rows = JobMetric.query.order_by(JobMetric.created_at.desc()).limit(200).all()
         html = "<h2>Job Metrics</h2><table border='1'>"
         html += "<tr><th>Time</th><th>Tool</th><th>Status</th><th>Task ID</th><th>In WxH</th><th>Frames</th><th>In Size</th><th>Out Size</th><th>Time (ms)</th><th>Options</th><th>Error</th></tr>"
@@ -174,9 +182,8 @@ def create_app():
         return html
 
     @app.route('/admin/job-metrics/summary')
+    @admin_required
     def metrics_summary():
-        if request.args.get('key') != ADMIN_KEY:
-            abort(401)
         try:
             import datetime
             hours = int(request.args.get('hours', 24))
@@ -204,13 +211,13 @@ def create_app():
 
     # API-prefixed aliases to avoid SPA catch-all in some deployments
     @app.route('/api/admin/job-metrics/summary')
+    @admin_required
     def api_metrics_summary_alias():
         return metrics_summary()
 
     @app.route('/admin/daily-metrics/rebuild')
+    @admin_required
     def rebuild_daily_metrics():
-        if request.args.get('key') != ADMIN_KEY:
-            abort(401)
         import datetime
         start = request.args.get('start')  # YYYY-MM-DD
         end = request.args.get('end')      # YYYY-MM-DD
@@ -253,13 +260,13 @@ def create_app():
             return {'error': str(e)}, 500
 
     @app.route('/api/admin/daily-metrics/rebuild')
+    @admin_required
     def api_rebuild_daily_metrics_alias():
         return rebuild_daily_metrics()
 
     @app.route('/admin/daily-metrics')
+    @admin_required
     def list_daily_metrics():
-        if request.args.get('key') != ADMIN_KEY:
-            abort(401)
         tool = request.args.get('tool')
         q = DailyMetric.query
         if tool:
@@ -268,10 +275,12 @@ def create_app():
         return {'items': [r.to_dict() for r in rows]}
 
     @app.route('/api/admin/daily-metrics')
+    @admin_required
     def api_list_daily_metrics_alias():
         return list_daily_metrics()
 
     @app.route('/api/admin/job-metrics')
+    @admin_required
     def api_view_job_metrics_alias():
         return view_job_metrics()
     # -------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `admin_required` decorator using Bearer token authentication
- protect admin endpoints with the decorator and environment-based `ADMIN_TOKEN`
- document new `ADMIN_TOKEN` in deployment guide

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a528002b0883299ad24b845f1a42fb