### PR TITLE
Consolidate temp file cleanup via Celery

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,5 +1,5 @@
 import os
-import tempfile
+from datetime import timedelta
 
 def fix_redis_ssl_url(url):
     """Add SSL cert requirements to rediss:// URLs if missing"""
@@ -17,6 +17,16 @@ class Config:
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', 'sqlite:///app.db')
     # Use local directory for uploads in development, Fly.io Volume in production
     UPLOAD_FOLDER = os.environ.get('UPLOAD_FOLDER', os.path.join(os.getcwd(), 'uploads'))
+
+    # Temporary file cleanup settings
+    TEMP_FILE_MAX_AGE = int(os.environ.get('TEMP_FILE_MAX_AGE', 7200))  # seconds
+    TEMP_FILE_CLEANUP_INTERVAL = int(os.environ.get('TEMP_FILE_CLEANUP_INTERVAL', 3600))  # seconds
+    CELERY_BEAT_SCHEDULE = {
+        "cleanup-old-temp-files": {
+            "task": "tasks.cleanup_old_files",
+            "schedule": timedelta(seconds=TEMP_FILE_CLEANUP_INTERVAL),
+        }
+    }
     
     @classmethod
     def get_celery_broker_url(cls):

--- a/src/tasks_cleanup.py
+++ b/src/tasks_cleanup.py
@@ -20,8 +20,8 @@ def cleanup_old_files():
             logging.info(f"User uploads directory does not exist, skipping: {user_uploads_dir}")
             return
 
-        # Use a configurable max age, defaulting to 2 hours
-        max_age_seconds = current_app.config.get('TEMP_FILE_MAX_AGE', 7200)
+        # Use a configurable max age
+        max_age_seconds = current_app.config.get('TEMP_FILE_MAX_AGE')
         now = time.time()
         deleted_count = 0
         
@@ -44,4 +44,4 @@ def cleanup_old_files():
     except Exception as e:
         logging.error(f"Error in cleanup task: {e}", exc_info=True)
 
-# To schedule: Use Celery beat or a cron job to call this task regularly.
+# Scheduled via Celery beat using TEMP_FILE_CLEANUP_INTERVAL.


### PR DESCRIPTION
## Summary
- Remove background thread-based temp file cleanup and rely solely on Celery task.
- Add configurable temp file max age and cleanup interval with Celery beat schedule.
- Ensure cleanup task imports and uses new configuration.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a528122048832989c1350b2d1d9fdc