### PR TITLE
Add GIF reverse task and endpoint

### DIFF
--- a/FRONTEND_INTEGRATION.md
+++ b/FRONTEND_INTEGRATION.md
@@ -87,6 +87,7 @@ python -m src.main
 - `https://easygifmaker.com/crop` (React tool)
 - `https://easygifmaker.com/optimize` (React tool)
 - `https://easygifmaker.com/add-text` (React tool)
+- `https://easygifmaker.com/reverse` (React tool using `/api/reverse`)
 
 ## 🎯 **Benefits of This Approach**
 

--- a/SEO_IMPLEMENTATION.md
+++ b/SEO_IMPLEMENTATION.md
@@ -81,7 +81,7 @@ def sitemap():
 - `/convert/avi-to-gif` - Convert AVI to GIF
 
 ### Features Category
-- `/features/reverse-gif` - Reverse GIF animation
+- `/features/reverse-gif` - Reverse GIF animation (powered by `/api/reverse`)
 - `/features/crop-gif` - Crop GIF tool
 - `/features/resize-gif` - Resize GIF tool
 


### PR DESCRIPTION
## Summary
- add `reverse_gif_task` Celery task to flip frames and save reversed GIFs
- expose `/api/reverse` endpoint that handles URL uploads or files and returns direct download link
- document new reverse endpoint in frontend integration and SEO guides

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a52a4e32d08329a854ced5dd4feb6f