### PR TITLE
feat: add rate limiting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ charset-normalizer==3.4.2
 click==8.2.1
 Flask==3.1.1
 flask-cors==6.0.0
+Flask-Limiter==3.7.0
 Flask-SQLAlchemy==3.1.1
 greenlet==3.2.3
 idna==3.10

--- a/src/main.py
+++ b/src/main.py
@@ -7,8 +7,11 @@ import threading
 import shutil
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from flask import Flask, send_from_directory, current_app, render_template, make_response, redirect, request, abort
+from flask import Flask, send_from_directory, current_app, render_template, make_response, redirect, request, abort, jsonify
 from flask_cors import CORS, cross_origin
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+from flask_limiter.errors import RateLimitExceeded
 from src.celery_app import celery as celery_app
 from src.models.user import db, APILog # Import APILog
 from src.models.metrics import JobMetric, DailyMetric
@@ -16,6 +19,9 @@ from src.config import DevelopmentConfig, ProductionConfig
 import requests
 import smtplib
 from email.message import EmailMessage
+
+
+limiter = Limiter(key_func=get_remote_address, default_limits=["200 per minute"])
 
 def clean_temp_files_task(app_context):
     """A background task that cleans up old temporary files."""
@@ -112,6 +118,8 @@ def create_app():
     # Initialize extensions
     CORS(app, resources={r"/api/*": {"origins": app.config['CORS_ORIGINS']}})
     db.init_app(app)
+    app.config.setdefault("RATELIMIT_HEADERS_ENABLED", True)
+    limiter.init_app(app)
 
     # Configure Celery with the Flask app context BEFORE importing blueprints/tasks
     configure_celery(app, celery_app)
@@ -136,6 +144,10 @@ def create_app():
     with app.app_context():
         # Create database tables if they don't exist
         db.create_all()
+
+    @app.errorhandler(RateLimitExceeded)
+    def handle_rate_limit(e):
+        return jsonify({"error": "Rate limit exceeded", "limit": str(e.description)}), 429
 
     # -------------------- Admin routes (defined BEFORE catch-all) --------------------
     ADMIN_KEY = os.environ.get('ADMIN_KEY', 'your-secret-key')

--- a/src/routes/gif.py
+++ b/src/routes/gif.py
@@ -18,11 +18,13 @@ import yt_dlp # Import yt_dlp
 from PIL import Image, ImageDraw, ImageFont
 
 from src.tasks import convert_video_to_gif_task, create_gif_from_images_task, resize_gif_task, crop_gif_task, optimize_gif_task, add_text_to_gif_task, add_text_layers_to_gif_task, handle_upload_task, orchestrate_gif_from_urls_task, download_file_from_url_task_helper
+from src.main import limiter
 
 gif_bp = Blueprint("gif", __name__)
 
 
 @gif_bp.route("/ai/convert", methods=["POST"])
+@limiter.limit("5 per minute")
 def convert():
     data = request.get_json()
     if not data or "url" not in data:
@@ -31,6 +33,7 @@ def convert():
     return jsonify({"message": "Conversion request received", "data": data}), 200
 
 @gif_bp.route("/ai/add-text", methods=["POST"])
+@limiter.limit("5 per minute")
 def ai_add_text_layers():
     """AI endpoint: Add text to GIF with multi-layer support via JSON.
     Accepts: { url | base64_data, layers: [ { text, font_family, font_size, color, stroke_color, stroke_width, horizontal_align, vertical_align, offset_x, offset_y, start_time, end_time, animation_style, max_width_ratio, line_height, auto_fit, font_url } ] }
@@ -161,6 +164,7 @@ def ai_add_text_layers():
         return jsonify({"error": "An unexpected error occurred while adding text to the GIF."}), 500
 
 @gif_bp.route("/gif-metadata", methods=["POST"])
+@limiter.limit("5 per minute")
 def gif_metadata():
     """Return duration (seconds) and frame count for a GIF file or URL."""
     try:
@@ -256,6 +260,7 @@ def get_aspect_ratio_dimensions(width, height, aspect_ratio):
 
 @gif_bp.route("/gif-maker", methods=["POST"])
 @cross_origin()
+@limiter.limit("5 per minute")
 def create_gif_from_images():
     """Create GIF from uploaded images or URLs"""
     try:
@@ -344,6 +349,7 @@ def create_gif_from_images():
 
 @gif_bp.route("/video-to-gif", methods=["POST"])
 @cross_origin()
+@limiter.limit("5 per minute")
 def convert_video_to_gif():
     """Convert video to GIF (optionally with audio as .mp4 for direct video links only)"""
     try:
@@ -407,6 +413,7 @@ def convert_video_to_gif():
         return jsonify({"error": str(e) if str(e) else "An unexpected error occurred during video conversion."}), 500
 
 @gif_bp.route("/resize", methods=["POST"])
+@limiter.limit("5 per minute")
 def resize_gif():
     """Resize GIF"""
     try:
@@ -473,6 +480,7 @@ def resize_gif():
         return jsonify({"error": "An unexpected error occurred while resizing the GIF."}), 500
 
 @gif_bp.route("/crop", methods=["POST"])
+@limiter.limit("5 per minute")
 def crop_gif():
     """Crop GIF with advanced options"""
     try:
@@ -525,6 +533,7 @@ def crop_gif():
         return jsonify({"error": "An unexpected error occurred while cropping the GIF."}), 500
 
 @gif_bp.route("/optimize", methods=["POST"])
+@limiter.limit("5 per minute")
 def optimize_gif():
     """Optimize GIF to reduce file size"""
     try:
@@ -577,6 +586,7 @@ def optimize_gif():
         return jsonify({"error": "An unexpected error occurred while optimizing the GIF."}), 500
 
 @gif_bp.route("/add-text", methods=["POST"])
+@limiter.limit("5 per minute")
 def add_text_to_gif():
     """Add text to GIF with advanced customization"""
     try:
@@ -683,6 +693,7 @@ def add_text_to_gif():
         return jsonify({"error": "An unexpected error occurred while adding text to the GIF."}), 500
 
 @gif_bp.route("/add-text-layers", methods=["POST"])
+@limiter.limit("5 per minute")
 def add_text_layers_to_gif():
     """Add multiple text layers to a GIF with per-layer customization and optional custom fonts."""
     try:
@@ -806,6 +817,7 @@ def health_check():
     })
 
 @gif_bp.route("/upload", methods=["POST"])
+@limiter.limit("5 per minute")
 def handle_upload():
     """Handle URL uploads and return the video file content as a direct response (for preview/playback)"""
     data = request.get_json()


### PR DESCRIPTION
## Summary
- integrate Flask-Limiter and configure global rate limits
- enforce per-IP limits on heavy GIF routes
- return JSON errors when rate limit exceeded

## Testing
- `pip install Flask-Limiter==3.7.0` *(fails: Could not find version that satisfies the requirement)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a52a5491548329b148304752a61e6d