### PR TITLE
Import reverse gif task in routes

### DIFF
--- a/src/routes/gif.py
+++ b/src/routes/gif.py
@@ -32,6 +32,7 @@ from src.tasks import (
     add_text_layers_to_gif_task,
     handle_upload_task,
     orchestrate_gif_from_urls_task,
+    reverse_gif_task,
     download_file_from_url_task_helper,
 )
 


### PR DESCRIPTION
## Summary
- import `reverse_gif_task` in gif routes to fix `/reverse` endpoint

## Testing
- `pytest`
- `python - <<'PY'
from io import BytesIO
from PIL import Image
from src.main import app
client = app.test_client()
frames = [Image.new('RGB', (400,400), color=color) for color in ['red','blue','green','yellow','purple']]
bytes_io = BytesIO()
frames[0].save(bytes_io, format='GIF', save_all=True, append_images=frames[1:], loop=0, duration=100)
bytes_io.seek(0)
resp = client.post('/api/reverse', data={'file': (bytes_io, 'test.gif')})
print('status', resp.status_code)
print('data', resp.get_json())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a5cf9dbc2c832991d725bb04c4dfd7