### PR TITLE
Remove gunicorn request limits

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -36,14 +36,11 @@ echo "[Entrypoint] Starting Gunicorn (web server) on 0.0.0.0:${PORT_TO_BIND} in 
 gunicorn -b 0.0.0.0:${PORT_TO_BIND} \
     --timeout=1800 \
     --keep-alive=10 \
-    --max-requests=50 \
-    --max-requests-jitter=5 \
     --worker-class=sync \
     --workers=1 \
     --worker-connections=10 \
     --limit-request-line=8192 \
     --limit-request-field_size=16384 \
-    --max-requests-jitter=5 \
     --preload \
     src.main:app &
 


### PR DESCRIPTION
## Summary
- remove `--max-requests` and `--max-requests-jitter` from startup script so the web worker is not recycled

## Testing
- `python test_indexnow_admin.py`
- `curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:5005/` (five requests to running gunicorn instance)


------
https://chatgpt.com/codex/tasks/task_e_68af552d0bb08329a840993a2b3aa3e8